### PR TITLE
hotfix to remove stars from default ccignore

### DIFF
--- a/src/main/java/cceclipseplugin/core/CCIgnore.java
+++ b/src/main/java/cceclipseplugin/core/CCIgnore.java
@@ -38,13 +38,13 @@ public class CCIgnore {
             "bin\n" +
             "build\n" +
             "target\n" +
-            "out\n" +
-            "\n" +
-            "*.o\n" +
-            "*.a\n" +
-            "*.so\n" +
-            "*.exe\n" +
-            "*.swp";
+            "out\n";
+//            "\n" +
+//            "*.o\n" +
+//            "*.a\n" +
+//            "*.so\n" +
+//            "*.exe\n" +
+//            "*.swp";
 
 	private Set<String> ignoredFiles = new HashSet<>();
 	


### PR DESCRIPTION
this avoids the bug on windows with stars inside of the path